### PR TITLE
#4 Alter post-processing methods to reduce occurrence of repeated code (WIP)

### DIFF
--- a/src/pheval_exomiser/post_process/post_process_results_format.py
+++ b/src/pheval_exomiser/post_process/post_process_results_format.py
@@ -3,13 +3,14 @@ import json
 from pathlib import Path
 
 import click
-import pandas as pd
 from pheval.post_processing.post_processing import (
     PhEvalGeneResult,
     PhEvalVariantResult,
     RankedPhEvalGeneResult,
     RankedPhEvalVariantResult,
-    create_pheval_result, write_pheval_gene_result, write_pheval_variant_result,
+    create_pheval_result,
+    write_pheval_gene_result,
+    write_pheval_variant_result,
 )
 from pheval.utils.file_utils import files_with_suffix
 

--- a/src/pheval_exomiser/post_process/post_process_results_format.py
+++ b/src/pheval_exomiser/post_process/post_process_results_format.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import click
 import pandas as pd
-from pheval.post_processing.post_processing import PhEvalGeneResult, PhEvalVariantResult
+from pheval.post_processing.post_processing import PhEvalGeneResult, PhEvalVariantResult, create_pheval_result
 from pheval.utils.file_utils import files_with_suffix
 from pheval.utils.phenopacket_utils import GenomicVariant
 
@@ -93,6 +93,18 @@ class PhEvalVariantResultFromExomiserJsonCreator:
         return simplified_exomiser_result
 
 
+def create_pheval_gene_result_from_exomiser(exomiser_json_result, ranking_method: str):
+    pheval_gene_result = PhEvalGeneResultFromExomiserJsonCreator(
+        exomiser_json_result, ranking_method
+    ).extract_pheval_gene_requirements()
+    return create_pheval_result(pheval_gene_result, ranking_method)
+
+
+def create_variant_gene_result_from_exomiser(exomiser_json_result, ranking_method: str):
+    pheval_variant_result = PhEvalVariantResultFromExomiserJsonCreator(
+        exomiser_json_result, ranking_method
+    ).extract_pheval_variant_requirements()
+    return create_pheval_result(pheval_variant_result, ranking_method)
 
 def create_standardised_results(results_dir: Path, output_dir: Path, ranking_method) -> None:
     """Write standardised gene and variant results from default Exomiser json output."""

--- a/src/pheval_exomiser/post_process/post_process_results_format.py
+++ b/src/pheval_exomiser/post_process/post_process_results_format.py
@@ -93,48 +93,6 @@ class PhEvalVariantResultFromExomiserJsonCreator:
         return simplified_exomiser_result
 
 
-class StandardiseExomiserResult:
-    """Standardise Exomiser output into simplified gene and variant results for analysis."""
-
-    def __init__(self, exomiser_json_result: [dict], ranking_method: str):
-        self.exomiser_json_result = exomiser_json_result
-        self.ranking_method = ranking_method
-
-    def simplify_gene_result(self) -> [dict]:
-        """Simplify Exomiser json output into gene results."""
-        simplified_exomiser_result = []
-        for result in self.exomiser_json_result:
-            if self.ranking_method in result:
-                simplified_exomiser_result = SimplifiedExomiserGeneResult(
-                    result, simplified_exomiser_result, self.ranking_method
-                ).create_simplified_gene_result()
-        return simplified_exomiser_result
-
-    def simplify_variant_result(self) -> [dict]:
-        """Simplify Exomiser json output into variant results."""
-        simplified_exomiser_result = []
-        for result in self.exomiser_json_result:
-            for gene_hit in result["geneScores"]:
-                if self.ranking_method in gene_hit:
-                    if "contributingVariants" in gene_hit:
-                        simplified_exomiser_result = SimplifiedExomiserVariantResult(
-                            gene_hit,
-                            simplified_exomiser_result,
-                            self.ranking_method,
-                            round(result[self.ranking_method], 4),
-                        ).create_simplified_variant_result()
-        return simplified_exomiser_result
-
-    def standardise_gene_result(self) -> [dict]:
-        """Standardise Exomiser json to gene results for analysis."""
-        simplified_exomiser_result = self.simplify_gene_result()
-        return RankExomiserResult(simplified_exomiser_result, self.ranking_method).rank_results()
-
-    def standardise_variant_result(self) -> [dict]:
-        """Standardise Exomiser json to gene results for analysis."""
-        simplified_exomiser_result = self.simplify_variant_result()
-        return RankExomiserResult(simplified_exomiser_result, self.ranking_method).rank_results()
-
 
 def create_standardised_results(results_dir: Path, output_dir: Path, ranking_method) -> None:
     """Write standardised gene and variant results from default Exomiser json output."""

--- a/src/pheval_exomiser/post_process/post_process_results_format.py
+++ b/src/pheval_exomiser/post_process/post_process_results_format.py
@@ -11,6 +11,14 @@ from pheval.utils.file_utils import files_with_suffix
 from pheval.utils.phenopacket_utils import GenomicVariant
 
 
+def read_exomiser_json_result(exomiser_result_path: Path) -> dict:
+    """Load Exomiser json result."""
+    with open(exomiser_result_path) as exomiser_json_result:
+        exomiser_result = json.load(exomiser_json_result)
+    exomiser_json_result.close()
+    return exomiser_result
+
+
 class PhEvalGeneResultFromExomiserJsonCreator:
 
     def __init__(self, exomiser_json_result: [dict], ranking_method: str):
@@ -38,6 +46,7 @@ class PhEvalGeneResultFromExomiserJsonCreator:
                                                                    score=self.find_relevant_score(result_entry)))
 
         return simplified_exomiser_result
+
 
 class PhEvalVariantResultFromExomiserJsonCreator:
     def __init__(self, exomiser_json_result: [dict], ranking_method: str):
@@ -82,14 +91,6 @@ class PhEvalVariantResultFromExomiserJsonCreator:
                                                                                   alt=self.find_alt(cv),
                                                                                   score=score))
         return simplified_exomiser_result
-
-
-def read_exomiser_json_result(exomiser_result_path: Path) -> dict:
-    """Load Exomiser json result."""
-    with open(exomiser_result_path) as exomiser_json_result:
-        exomiser_result = json.load(exomiser_json_result)
-    exomiser_json_result.close()
-    return exomiser_result
 
 
 class StandardiseExomiserResult:

--- a/src/pheval_exomiser/post_process/post_process_results_format.py
+++ b/src/pheval_exomiser/post_process/post_process_results_format.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import click
 import pandas as pd
 from pheval.utils.file_utils import files_with_suffix
-from pheval.utils.phenopacket_utils import VariantData
+from pheval.utils.phenopacket_utils import GenomicVariant
 
 
 @dataclass
@@ -51,12 +51,11 @@ class SimplifiedExomiserVariantResult:
             self.simplified_exomiser_variant_result.append(
                 {
                     "variant": dataclasses.asdict(
-                        VariantData(
+                        GenomicVariant(
                             cv["contigName"],
                             cv["start"],
                             cv["ref"],
                             cv["alt"],
-                            self.exomiser_result["geneIdentifier"]["geneSymbol"],
                         )
                     ),
                     "score": self.ranking_score,

--- a/src/pheval_exomiser/post_process/post_process_results_format.py
+++ b/src/pheval_exomiser/post_process/post_process_results_format.py
@@ -38,7 +38,7 @@ class PhEvalGeneResultFromExomiserJsonCreator:
     def find_relevant_score(self, result_entry: dict):
         return round(result_entry[self.ranking_method], 4)
 
-    def extract_pheval_gene_requirements(self):
+    def extract_pheval_gene_requirements(self) -> [PhEvalGeneResult]:
         simplified_exomiser_result = []
         for result_entry in self.exomiser_json_result:
             if self.ranking_method in result_entry:
@@ -59,29 +59,29 @@ class PhEvalVariantResultFromExomiserJsonCreator:
         self.ranking_method = ranking_method
 
     @staticmethod
-    def find_chromosome(result_entry):
+    def find_chromosome(result_entry: dict) -> str:
         return result_entry["contigName"]
 
     @staticmethod
-    def find_start_pos(result_entry):
+    def find_start_pos(result_entry: dict) -> int:
         return result_entry["start"]
 
     @staticmethod
-    def find_end_pos(result_entry):
+    def find_end_pos(result_entry: dict) -> int:
         return result_entry["end"]
 
     @staticmethod
-    def find_ref(result_entry):
+    def find_ref(result_entry: dict) -> str:
         return result_entry["ref"]
 
     @staticmethod
-    def find_alt(result_entry):
+    def find_alt(result_entry: dict) -> str:
         return result_entry["alt"]
 
-    def find_relevant_score(self, result_entry):
+    def find_relevant_score(self, result_entry) -> float:
         return round(result_entry[self.ranking_method], 4)
 
-    def extract_pheval_variant_requirements(self):
+    def extract_pheval_variant_requirements(self) -> [PhEvalVariantResult]:
         simplified_exomiser_result = []
         for result_entry in self.exomiser_json_result:
             for gene_hit in result_entry["geneScores"]:
@@ -102,14 +102,18 @@ class PhEvalVariantResultFromExomiserJsonCreator:
         return simplified_exomiser_result
 
 
-def create_pheval_gene_result_from_exomiser(exomiser_json_result, ranking_method: str):
+def create_pheval_gene_result_from_exomiser(
+    exomiser_json_result: [dict], ranking_method: str
+) -> [RankedPhEvalGeneResult]:
     pheval_gene_result = PhEvalGeneResultFromExomiserJsonCreator(
         exomiser_json_result, ranking_method
     ).extract_pheval_gene_requirements()
     return create_pheval_result(pheval_gene_result, ranking_method)
 
 
-def create_variant_gene_result_from_exomiser(exomiser_json_result, ranking_method: str):
+def create_variant_gene_result_from_exomiser(
+    exomiser_json_result: [dict], ranking_method: str
+) -> [RankedPhEvalVariantResult]:
     pheval_variant_result = PhEvalVariantResultFromExomiserJsonCreator(
         exomiser_json_result, ranking_method
     ).extract_pheval_variant_requirements()
@@ -190,7 +194,7 @@ def create_standardised_results(results_dir: Path, output_dir: Path, ranking_met
     default="combinedScore",
     show_default=True,
 )
-def post_process_exomiser_results(output_dir: Path, results_dir: Path, ranking_method):
+def post_process_exomiser_results(output_dir: Path, results_dir: Path, ranking_method: str):
     """Post-process Exomiser json results into standardised gene and variant outputs."""
     output_dir.mkdir(exist_ok=True, parents=True)
     create_standardised_results(results_dir, output_dir, ranking_method)

--- a/src/pheval_exomiser/post_process/post_process_results_format.py
+++ b/src/pheval_exomiser/post_process/post_process_results_format.py
@@ -174,8 +174,5 @@ def create_standardised_results(results_dir: Path, output_dir: Path, ranking_met
 )
 def post_process_exomiser_results(output_dir: Path, results_dir: Path, ranking_method):
     """Post-process Exomiser json results into standardised gene and variant outputs."""
-    try:
-        output_dir.mkdir()
-    except FileExistsError:
-        pass
+    output_dir.mkdir(exist_ok=True, parents=True)
     create_standardised_results(results_dir, output_dir, ranking_method)

--- a/src/pheval_exomiser/post_process/post_process_results_format.py
+++ b/src/pheval_exomiser/post_process/post_process_results_format.py
@@ -1,7 +1,5 @@
 #!/usr/bin/python
-import dataclasses
 import json
-from dataclasses import dataclass
 from pathlib import Path
 
 import click
@@ -11,7 +9,6 @@ from pheval.post_processing.post_processing import (
     RankedPhEvalVariantResult, RankedPhEvalGeneResult
 )
 from pheval.utils.file_utils import files_with_suffix
-from pheval.utils.phenopacket_utils import GenomicVariant
 
 
 def read_exomiser_json_result(exomiser_result_path: Path) -> dict:

--- a/src/pheval_exomiser/post_process/post_process_results_format.py
+++ b/src/pheval_exomiser/post_process/post_process_results_format.py
@@ -64,47 +64,6 @@ class SimplifiedExomiserVariantResult:
         return self.simplified_exomiser_variant_result
 
 
-class RankExomiserResult:
-    """Add ranks to simplified Exomiser gene/variant results - taking care of ex-aequo scores."""
-
-    def __init__(self, simplified_exomiser_result: [dict], ranking_method: str):
-        self.simplified_exomiser_result = simplified_exomiser_result
-        self.ranking_method = ranking_method
-
-    def sort_exomiser_result(self) -> [dict]:
-        """Sorts simplified Exomiser result by ranking method in decreasing order."""
-        return sorted(
-            self.simplified_exomiser_result,
-            key=lambda d: d["score"],
-            reverse=True,
-        )
-
-    def sort_exomiser_result_pvalue(self) -> [dict]:
-        """Sort simplified Exomiser result by pvalue, most significant value first."""
-        return sorted(
-            self.simplified_exomiser_result,
-            key=lambda d: d["score"],
-            reverse=False,
-        )
-
-    def rank_results(self) -> [dict]:
-        """Add ranks to the Exomiser results, equal scores are given the same rank e.g., 1,1,3."""
-        sorted_exomiser_result = (
-            self.sort_exomiser_result_pvalue()
-            if self.ranking_method == "pValue"
-            else self.sort_exomiser_result()
-        )
-        rank, count, previous = 0, 0, None
-        for exomiser_result in sorted_exomiser_result:
-            count += 1
-            if exomiser_result["score"] != previous:
-                rank += count
-                previous = exomiser_result["score"]
-                count = 0
-            exomiser_result["rank"] = rank
-        return sorted_exomiser_result
-
-
 def read_exomiser_json_result(exomiser_result_path: Path) -> dict:
     """Load Exomiser json result."""
     with open(exomiser_result_path) as exomiser_json_result:

--- a/src/pheval_exomiser/post_process/post_process_results_format.py
+++ b/src/pheval_exomiser/post_process/post_process_results_format.py
@@ -6,7 +6,10 @@ from pathlib import Path
 
 import click
 import pandas as pd
-from pheval.post_processing.post_processing import PhEvalGeneResult, PhEvalVariantResult, create_pheval_result
+from pheval.post_processing.post_processing import (
+    PhEvalGeneResult, PhEvalVariantResult, create_pheval_result,
+    RankedPhEvalVariantResult, RankedPhEvalGeneResult
+)
 from pheval.utils.file_utils import files_with_suffix
 from pheval.utils.phenopacket_utils import GenomicVariant
 
@@ -105,6 +108,31 @@ def create_variant_gene_result_from_exomiser(exomiser_json_result, ranking_metho
         exomiser_json_result, ranking_method
     ).extract_pheval_variant_requirements()
     return create_pheval_result(pheval_variant_result, ranking_method)
+
+
+def write_pheval_gene_result(ranked_pheval_result: [RankedPhEvalGeneResult], output_dir: Path,
+                             tool_result_path: Path) -> None:
+    """Write ranked PhEval gene result to tsv."""
+    ranked_result = pd.DataFrame([x.as_dict() for x in ranked_pheval_result])
+    pheval_gene_output = ranked_result.loc[:, ["rank", "score", "gene_symbol", "gene_identifier"]]
+    pheval_gene_output.to_csv(
+        output_dir.joinpath("pheval_gene_results/" + tool_result_path.stem + "-pheval_gene_result.tsv"),
+        sep="\t",
+        index=False,
+    )
+
+
+def write_pheval_variant_result(ranked_pheval_result: [RankedPhEvalVariantResult],
+                                output_dir: Path, tool_result_path: Path) -> None:
+    """Write ranked PhEval variant result to tsv."""
+    ranked_result = pd.DataFrame([x.as_dict() for x in ranked_pheval_result])
+    pheval_variant_output = ranked_result.loc[:, ["rank", "score", "chromosome", "start", "end", "ref", "alt"]]
+    pheval_variant_output.to_csv(
+        output_dir.joinpath("pheval_variant_results/" + tool_result_path.stem + "-pheval_variant_result.tsv"),
+        sep="\t",
+        index=False,
+    )
+
 
 def create_standardised_results(results_dir: Path, output_dir: Path, ranking_method) -> None:
     """Write standardised gene and variant results from default Exomiser json output."""

--- a/src/pheval_exomiser/post_process/post_process_results_format.py
+++ b/src/pheval_exomiser/post_process/post_process_results_format.py
@@ -154,8 +154,8 @@ def write_pheval_variant_result(
 
 def create_standardised_results(results_dir: Path, output_dir: Path, ranking_method: str) -> None:
     """Write standardised gene and variant results from default Exomiser json output."""
-    output_dir.joinpath("pheval_gene_results/").mkdir(exist_ok=True)
-    output_dir.joinpath("pheval_variant_results/").mkdir(exist_ok=True)
+    output_dir.joinpath("pheval_gene_results/").mkdir(exist_ok=True, parents=True)
+    output_dir.joinpath("pheval_variant_results/").mkdir(exist_ok=True, parents=True)
     for result in files_with_suffix(results_dir, ".json"):
         exomiser_result = read_exomiser_json_result(result)
         pheval_gene_result = create_pheval_gene_result_from_exomiser(

--- a/src/pheval_exomiser/prepare/create_batch_commands.py
+++ b/src/pheval_exomiser/prepare/create_batch_commands.py
@@ -388,6 +388,14 @@ def create_batch_file(
     help="Path to VCF files.",
 )
 @click.option(
+    "--output-dir",
+    "-out",
+    required=True,
+    metavar="PATH",
+    type=Path,
+    help="Path to output directory.",
+)
+@click.option(
     "--batch-prefix",
     "-b",
     required=False,

--- a/src/pheval_exomiser/runner.py
+++ b/src/pheval_exomiser/runner.py
@@ -22,22 +22,6 @@ class ExomiserPhEvalRunner(PhEvalRunner):
     def prepare(self):
         """prepare"""
         print("preparing")
-        # config = parse_exomiser_config(self.config_file)
-        # try:
-        #     Path(self.input_dir).mkdir()
-        # except FileExistsError:
-        #     pass
-        # prepare_updated_phenopackets(
-        #     input_dir=Path(self.input_dir).joinpath("phenopackets"),
-        #     testdata_dir=Path(self.testdata_dir),
-        #     config=config,
-        # )
-        # prepare_scrambled_phenopackets(
-        #     input_dir=Path(self.input_dir), testdata_dir=Path(self.testdata_dir), config=config
-        # )
-        # prepare_spiked_vcfs(
-        #     input_dir=Path(self.input_dir), testdata_dir=Path(self.testdata_dir), config=config
-        # )
 
     def run(self):
         """run"""

--- a/tests/test_post_process_results_format.py
+++ b/tests/test_post_process_results_format.py
@@ -1,14 +1,17 @@
 import unittest
 
 from pheval.post_processing.post_processing import (
-    PhEvalGeneResult, PhEvalVariantResult, RankedPhEvalGeneResult,
-    RankedPhEvalVariantResult
+    PhEvalGeneResult,
+    PhEvalVariantResult,
+    RankedPhEvalGeneResult,
+    RankedPhEvalVariantResult,
 )
 
 from pheval_exomiser.post_process.post_process_results_format import (
     PhEvalGeneResultFromExomiserJsonCreator,
-    PhEvalVariantResultFromExomiserJsonCreator, create_pheval_gene_result_from_exomiser,
-    create_variant_gene_result_from_exomiser
+    PhEvalVariantResultFromExomiserJsonCreator,
+    create_pheval_gene_result_from_exomiser,
+    create_variant_gene_result_from_exomiser,
 )
 
 example_exomiser_result = [
@@ -1676,29 +1679,43 @@ example_exomiser_result = [
 class TestPhEvalGeneResultFromExomiserJsonCreator(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
-        cls.json_result = PhEvalGeneResultFromExomiserJsonCreator(example_exomiser_result, "combinedScore")
+        cls.json_result = PhEvalGeneResultFromExomiserJsonCreator(
+            example_exomiser_result, "combinedScore"
+        )
 
     def test_find_gene_symbol(self):
-        self.assertEqual(self.json_result.find_gene_symbol(result_entry=example_exomiser_result[0]), "PLXNA1")
+        self.assertEqual(
+            self.json_result.find_gene_symbol(result_entry=example_exomiser_result[0]), "PLXNA1"
+        )
 
     def test_find_gene_identifier(self):
-        self.assertEqual(self.json_result.find_gene_identifier(result_entry=example_exomiser_result[0]),
-                         "ENSG00000114554")
+        self.assertEqual(
+            self.json_result.find_gene_identifier(result_entry=example_exomiser_result[0]),
+            "ENSG00000114554",
+        )
 
     def test_find_relevant_score(self):
-        self.assertEqual(self.json_result.find_relevant_score(result_entry=example_exomiser_result[0]), 0.0484)
+        self.assertEqual(
+            self.json_result.find_relevant_score(result_entry=example_exomiser_result[0]), 0.0484
+        )
 
     def test_extract_pheval_gene_requirements(self):
-        self.assertEqual(self.json_result.extract_pheval_gene_requirements(),
-                         [PhEvalGeneResult(gene_symbol='PLXNA1', gene_identifier='ENSG00000114554', score=0.0484)]
-                         )
+        self.assertEqual(
+            self.json_result.extract_pheval_gene_requirements(),
+            [
+                PhEvalGeneResult(
+                    gene_symbol="PLXNA1", gene_identifier="ENSG00000114554", score=0.0484
+                )
+            ],
+        )
 
 
 class TestPhEvalVariantFromExomiserJsonCreator(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
-        cls.json_result = PhEvalVariantResultFromExomiserJsonCreator(exomiser_json_result=example_exomiser_result,
-                                                                     ranking_method="combinedScore")
+        cls.json_result = PhEvalVariantResultFromExomiserJsonCreator(
+            exomiser_json_result=example_exomiser_result, ranking_method="combinedScore"
+        )
         cls.result_entry = example_exomiser_result[0]["geneScores"][0]["contributingVariants"][0]
 
     def test_find_chromosome(self):
@@ -1717,71 +1734,143 @@ class TestPhEvalVariantFromExomiserJsonCreator(unittest.TestCase):
         self.assertEqual(self.json_result.find_alt(result_entry=self.result_entry), "A")
 
     def test_find_relevant_score(self):
-        self.assertEqual(self.json_result.find_relevant_score(result_entry=example_exomiser_result[0]["geneScores"][0]),
-                         0.0484)
+        self.assertEqual(
+            self.json_result.find_relevant_score(
+                result_entry=example_exomiser_result[0]["geneScores"][0]
+            ),
+            0.0484,
+        )
 
     def test_extract_pheval_variant_requirements(self):
-        self.assertEqual(self.json_result.extract_pheval_variant_requirements(),
-                         [PhEvalVariantResult(chromosome='3', start=126730873, end=126730873, ref='G', alt='A',
-                                              score=0.0484),
-                          PhEvalVariantResult(chromosome='3', start=126730873, end=126730873, ref='G', alt='A',
-                                              score=0.0484),
-                          PhEvalVariantResult(chromosome='3', start=126741108, end=126741108, ref='G', alt='A',
-                                              score=0.0484)]
-                         )
+        self.assertEqual(
+            self.json_result.extract_pheval_variant_requirements(),
+            [
+                PhEvalVariantResult(
+                    chromosome="3", start=126730873, end=126730873, ref="G", alt="A", score=0.0484
+                ),
+                PhEvalVariantResult(
+                    chromosome="3", start=126730873, end=126730873, ref="G", alt="A", score=0.0484
+                ),
+                PhEvalVariantResult(
+                    chromosome="3", start=126741108, end=126741108, ref="G", alt="A", score=0.0484
+                ),
+            ],
+        )
 
 
 class TestCreatePhEvalGeneResultFromExomiser(unittest.TestCase):
     def test_create_pheval_gene_result_from_exomiser(self):
-        self.assertEqual(create_pheval_gene_result_from_exomiser(exomiser_json_result=example_exomiser_result,
-                                                                 ranking_method="combinedScore"),
-                         [RankedPhEvalGeneResult(
-                             pheval_gene_result=PhEvalGeneResult(gene_symbol='PLXNA1',
-                                                                 gene_identifier='ENSG00000114554',
-                                                                 score=0.0484), rank=1)]
-                         )
+        self.assertEqual(
+            create_pheval_gene_result_from_exomiser(
+                exomiser_json_result=example_exomiser_result, ranking_method="combinedScore"
+            ),
+            [
+                RankedPhEvalGeneResult(
+                    pheval_gene_result=PhEvalGeneResult(
+                        gene_symbol="PLXNA1", gene_identifier="ENSG00000114554", score=0.0484
+                    ),
+                    rank=1,
+                )
+            ],
+        )
 
     def test_create_pheval_gene_result_from_exomiser_pvalue(self):
-        self.assertEqual(create_pheval_gene_result_from_exomiser(exomiser_json_result=example_exomiser_result,
-                                                                 ranking_method="pValue"),
-                         [RankedPhEvalGeneResult(
-                             pheval_gene_result=PhEvalGeneResult(gene_symbol='PLXNA1',
-                                                                 gene_identifier='ENSG00000114554',
-                                                                 score=0.1876), rank=1)]
-                         )
+        self.assertEqual(
+            create_pheval_gene_result_from_exomiser(
+                exomiser_json_result=example_exomiser_result, ranking_method="pValue"
+            ),
+            [
+                RankedPhEvalGeneResult(
+                    pheval_gene_result=PhEvalGeneResult(
+                        gene_symbol="PLXNA1", gene_identifier="ENSG00000114554", score=0.1876
+                    ),
+                    rank=1,
+                )
+            ],
+        )
 
 
 class TestCreateVariantGeneResultFromExomiser(unittest.TestCase):
     def test_create_variant_gene_result_from_exomiser(self):
-        self.assertEqual(create_variant_gene_result_from_exomiser(exomiser_json_result=example_exomiser_result,
-                                                                  ranking_method="variantScore"),
-                         [RankedPhEvalVariantResult(
-                             pheval_variant_result=PhEvalVariantResult(chromosome='3', start=126730873, end=126730873,
-                                                                       ref='G',
-                                                                       alt='A', score=0.5566), rank=1),
-                             RankedPhEvalVariantResult(
-                                 pheval_variant_result=PhEvalVariantResult(chromosome='3', start=126730873,
-                                                                           end=126730873, ref='G',
-                                                                           alt='A', score=0.5566), rank=1),
-                             RankedPhEvalVariantResult(
-                                 pheval_variant_result=PhEvalVariantResult(chromosome='3', start=126741108,
-                                                                           end=126741108, ref='G',
-                                                                           alt='A', score=0.5566), rank=1)]
-                         )
+        self.assertEqual(
+            create_variant_gene_result_from_exomiser(
+                exomiser_json_result=example_exomiser_result, ranking_method="variantScore"
+            ),
+            [
+                RankedPhEvalVariantResult(
+                    pheval_variant_result=PhEvalVariantResult(
+                        chromosome="3",
+                        start=126730873,
+                        end=126730873,
+                        ref="G",
+                        alt="A",
+                        score=0.5566,
+                    ),
+                    rank=1,
+                ),
+                RankedPhEvalVariantResult(
+                    pheval_variant_result=PhEvalVariantResult(
+                        chromosome="3",
+                        start=126730873,
+                        end=126730873,
+                        ref="G",
+                        alt="A",
+                        score=0.5566,
+                    ),
+                    rank=1,
+                ),
+                RankedPhEvalVariantResult(
+                    pheval_variant_result=PhEvalVariantResult(
+                        chromosome="3",
+                        start=126741108,
+                        end=126741108,
+                        ref="G",
+                        alt="A",
+                        score=0.5566,
+                    ),
+                    rank=1,
+                ),
+            ],
+        )
 
     def test_create_variant_gene_result_from_exomiser_pvalue(self):
-        self.assertEqual(create_variant_gene_result_from_exomiser(exomiser_json_result=example_exomiser_result,
-                                                                  ranking_method="pValue"),
-                         [RankedPhEvalVariantResult(
-                             pheval_variant_result=PhEvalVariantResult(chromosome='3', start=126730873, end=126730873,
-                                                                       ref='G',
-                                                                       alt='A', score=0.1876), rank=1),
-                             RankedPhEvalVariantResult(
-                                 pheval_variant_result=PhEvalVariantResult(chromosome='3', start=126730873,
-                                                                           end=126730873, ref='G',
-                                                                           alt='A', score=0.1876), rank=1),
-                             RankedPhEvalVariantResult(
-                                 pheval_variant_result=PhEvalVariantResult(chromosome='3', start=126741108,
-                                                                           end=126741108, ref='G',
-                                                                           alt='A', score=0.1876), rank=1)]
-                         )
+        self.assertEqual(
+            create_variant_gene_result_from_exomiser(
+                exomiser_json_result=example_exomiser_result, ranking_method="pValue"
+            ),
+            [
+                RankedPhEvalVariantResult(
+                    pheval_variant_result=PhEvalVariantResult(
+                        chromosome="3",
+                        start=126730873,
+                        end=126730873,
+                        ref="G",
+                        alt="A",
+                        score=0.1876,
+                    ),
+                    rank=1,
+                ),
+                RankedPhEvalVariantResult(
+                    pheval_variant_result=PhEvalVariantResult(
+                        chromosome="3",
+                        start=126730873,
+                        end=126730873,
+                        ref="G",
+                        alt="A",
+                        score=0.1876,
+                    ),
+                    rank=1,
+                ),
+                RankedPhEvalVariantResult(
+                    pheval_variant_result=PhEvalVariantResult(
+                        chromosome="3",
+                        start=126741108,
+                        end=126741108,
+                        ref="G",
+                        alt="A",
+                        score=0.1876,
+                    ),
+                    rank=1,
+                ),
+            ],
+        )


### PR DESCRIPTION
Updated methods for post-processing of Exomiser json results into PhEval gene and variant output using the "common" methods moved to the PhEval repo. This should perform as it should once [PR#54 ](https://github.com/monarch-initiative/pheval/pull/54#issue-1572534718) in the PhEval repo is merged