### PR TITLE
12 remove exomiser filename suffix from constants

### DIFF
--- a/src/pheval_exomiser/constants.py
+++ b/src/pheval_exomiser/constants.py
@@ -1,0 +1,1 @@
+EXOMISER_FILE_SUFFIX = "-exomiser"

--- a/src/pheval_exomiser/constants.py
+++ b/src/pheval_exomiser/constants.py
@@ -1,1 +1,0 @@
-EXOMISER_FILE_SUFFIX = "-exomiser"

--- a/src/pheval_exomiser/post_process/post_process_results_format.py
+++ b/src/pheval_exomiser/post_process/post_process_results_format.py
@@ -15,6 +15,8 @@ from pheval.post_processing.post_processing import (
 from pheval.runners.runner import PhEvalRunner
 from pheval.utils.file_utils import files_with_suffix
 
+from pheval_exomiser.constants import EXOMISER_FILE_SUFFIX
+
 
 def read_exomiser_json_result(exomiser_result_path: Path) -> dict:
     """Load Exomiser json result."""
@@ -26,7 +28,7 @@ def read_exomiser_json_result(exomiser_result_path: Path) -> dict:
 
 def trim_exomiser_result_filename(exomiser_result_path: Path) -> Path:
     """Trim suffix appended to Exomiser JSON result path."""
-    return Path(str(exomiser_result_path).replace("-exomiser", ""))
+    return Path(str(exomiser_result_path).replace(EXOMISER_FILE_SUFFIX, ""))
 
 
 class PhEvalGeneResultFromExomiserJsonCreator:

--- a/src/pheval_exomiser/post_process/post_process_results_format.py
+++ b/src/pheval_exomiser/post_process/post_process_results_format.py
@@ -15,8 +15,6 @@ from pheval.post_processing.post_processing import (
 from pheval.runners.runner import PhEvalRunner
 from pheval.utils.file_utils import files_with_suffix
 
-from pheval_exomiser.constants import EXOMISER_FILE_SUFFIX
-
 
 def read_exomiser_json_result(exomiser_result_path: Path) -> dict:
     """Load Exomiser json result."""
@@ -28,7 +26,7 @@ def read_exomiser_json_result(exomiser_result_path: Path) -> dict:
 
 def trim_exomiser_result_filename(exomiser_result_path: Path) -> Path:
     """Trim suffix appended to Exomiser JSON result path."""
-    return Path(str(exomiser_result_path).replace(EXOMISER_FILE_SUFFIX, ""))
+    return Path(str(exomiser_result_path).replace("-exomiser", ""))
 
 
 class PhEvalGeneResultFromExomiserJsonCreator:


### PR DESCRIPTION
Removed the `constants.py` as it only contained the constant of the exomiser filename suffix `-exomiser` that was used once in the `trim_exomiser_result_filename()` method. Instead, specified this as a string within the method