### PR TITLE
30 fix variable inputs to create standardised results method

### DIFF
--- a/src/pheval_exomiser/post_process/post_process.py
+++ b/src/pheval_exomiser/post_process/post_process.py
@@ -1,17 +1,15 @@
 from pathlib import Path
 
-from pheval.runners.runner import PhEvalRunner
-
 from pheval_exomiser.config_parser import ExomiserConfig
 from pheval_exomiser.post_process.post_process_results_format import create_standardised_results
 
 
-def post_process_result_format(config: ExomiserConfig, raw_results_dir: Path, runner: PhEvalRunner):
+def post_process_result_format(config: ExomiserConfig, raw_results_dir: Path, output_dir: Path):
     """Standardise Exomiser json format to separated gene and variant results."""
     print("...standardising results format...")
     create_standardised_results(
         results_dir=raw_results_dir,
-        runner=runner,
+        output_dir=output_dir,
         score_name=config.post_process.score_name,
         sort_order=config.post_process.sort_order,
         phenotype_only=config.run.phenotype_only,

--- a/src/pheval_exomiser/post_process/post_process_results_format.py
+++ b/src/pheval_exomiser/post_process/post_process_results_format.py
@@ -8,7 +8,6 @@ from pheval.post_processing.post_processing import (
     PhEvalVariantResult,
     generate_pheval_result,
 )
-from pheval.runners.runner import PhEvalRunner
 from pheval.utils.file_utils import files_with_suffix
 
 
@@ -117,7 +116,7 @@ class PhEvalVariantResultFromExomiserJsonCreator:
 
 
 def create_standardised_results(
-    results_dir: Path, runner: PhEvalRunner, score_name: str, sort_order: str, phenotype_only: bool
+    results_dir: Path, output_dir: Path, score_name: str, sort_order: str, phenotype_only: bool
 ) -> None:
     """Write standardised gene and variant results from default Exomiser json output."""
     for exomiser_json_result in files_with_suffix(results_dir, ".json"):
@@ -128,7 +127,7 @@ def create_standardised_results(
         generate_pheval_result(
             pheval_result=pheval_gene_requirements,
             sort_order_str=sort_order,
-            output_dir=runner.output_dir,
+            output_dir=output_dir,
             tool_result_path=exomiser_json_result,
         )
         if not phenotype_only:
@@ -138,7 +137,7 @@ def create_standardised_results(
             generate_pheval_result(
                 pheval_result=pheval_variant_requirements,
                 sort_order_str=sort_order,
-                output_dir=runner.output_dir,
+                output_dir=output_dir,
                 tool_result_path=exomiser_json_result,
             )
 

--- a/src/pheval_exomiser/runner.py
+++ b/src/pheval_exomiser/runner.py
@@ -48,4 +48,6 @@ class ExomiserPhEvalRunner(PhEvalRunner):
         """post_process"""
         print("post processing")
         config = parse_exomiser_config(self.config_file)
-        post_process_result_format(config=config, raw_results_dir=self.raw_results_dir, runner=self)
+        post_process_result_format(
+            config=config, raw_results_dir=self.raw_results_dir, output_dir=self.output_dir
+        )


### PR DESCRIPTION
Changed the `runner` input variable to the `output_dir` in method `create_standardised_results()`. This allowed the method to function in both the standalone click command for post-processing the exomiser json results and when called within the `run` command