### PR TITLE
Strip angled brackets from Exomiser json `alt` field

### DIFF
--- a/src/pheval_exomiser/post_process/post_process_results_format.py
+++ b/src/pheval_exomiser/post_process/post_process_results_format.py
@@ -88,7 +88,10 @@ class PhEvalVariantResultFromExomiserJsonCreator:
     @staticmethod
     def _find_alt(result_entry: dict) -> str:
         """Return alternate allele from Exomiser result entry."""
-        return result_entry["alt"].strip(">").strip("<")
+        if "alt" in result_entry and result_entry["alt"] is not None:
+            return result_entry["alt"].strip(">").strip("<")
+        else:
+            return ""
 
     def _find_relevant_score(self, result_entry) -> float:
         """Return score from Exomiser result entry."""

--- a/src/pheval_exomiser/post_process/post_process_results_format.py
+++ b/src/pheval_exomiser/post_process/post_process_results_format.py
@@ -88,7 +88,7 @@ class PhEvalVariantResultFromExomiserJsonCreator:
     @staticmethod
     def _find_alt(result_entry: dict) -> str:
         """Return alternate allele from Exomiser result entry."""
-        return result_entry["alt"]
+        return result_entry["alt"].strip(">").strip("<")
 
     def _find_relevant_score(self, result_entry) -> float:
         """Return score from Exomiser result entry."""

--- a/tests/test_post_process_results_format.py
+++ b/tests/test_post_process_results_format.py
@@ -1,4 +1,5 @@
 import unittest
+from copy import copy
 
 from pheval.post_processing.post_processing import PhEvalGeneResult, PhEvalVariantResult
 
@@ -1727,6 +1728,16 @@ class TestPhEvalVariantFromExomiserJsonCreator(unittest.TestCase):
 
     def test_find_alt(self):
         self.assertEqual(self.json_result._find_alt(result_entry=self.result_entry), "A")
+
+    def test_find_alt_sv(self):
+        copied_result_entry = copy(dict(self.result_entry))
+        copied_result_entry["alt"] = "<DEL>"
+        self.assertEqual(self.json_result._find_alt(result_entry=copied_result_entry), "DEL")
+
+    def test_find_alt_none(self):
+        copied_result_entry = copy(dict(self.result_entry))
+        copied_result_entry["alt"] = None
+        self.assertEqual(self.json_result._find_alt(result_entry=copied_result_entry), "")
 
     def test_find_relevant_score(self):
         self.assertEqual(


### PR DESCRIPTION
Structural variants are reported in the Exomiser json results in angled brackets, e.g., `<DEL>` or `<INS>`. These need to be removed for accurate comparison with what is reported in the phenopackets