### PR TITLE
changing VCF to vcf in fileFormat phenopacket testdata

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -404,7 +404,7 @@ testing = ["covdefaults (>=2.2.2)", "coverage (>=7.0.1)", "pytest (>=7.2)", "pyt
 
 [[package]]
 name = "fonttools"
-version = "4.39.3"
+version = "4.39.4"
 description = "Tools to manipulate font files"
 category = "main"
 optional = false
@@ -1235,7 +1235,7 @@ tqdm = ">=4.64.1"
 type = "git"
 url = "https://github.com/monarch-initiative/pheval.git"
 reference = "HEAD"
-resolved_reference = "74578bf432970a1c13fed7eb12b34005a37a495c"
+resolved_reference = "a56a8ac6a514485a0c0b333daf06854bd5c35904"
 
 [[package]]
 name = "pillow"
@@ -2689,8 +2689,8 @@ filelock = [
     {file = "filelock-3.9.0.tar.gz", hash = "sha256:7b319f24340b51f55a2bf7a12ac0755a9b03e718311dac567a0f4f7fabd2f5de"},
 ]
 fonttools = [
-    {file = "fonttools-4.39.3-py3-none-any.whl", hash = "sha256:64c0c05c337f826183637570ac5ab49ee220eec66cf50248e8df527edfa95aeb"},
-    {file = "fonttools-4.39.3.zip", hash = "sha256:9234b9f57b74e31b192c3fc32ef1a40750a8fbc1cd9837a7b7bfc4ca4a5c51d7"},
+    {file = "fonttools-4.39.4-py3-none-any.whl", hash = "sha256:106caf6167c4597556b31a8d9175a3fdc0356fdcd70ab19973c3b0d4c893c461"},
+    {file = "fonttools-4.39.4.zip", hash = "sha256:dba8d7cdb8e2bac1b3da28c5ed5960de09e59a2fe7e63bb73f5a59e57b0430d2"},
 ]
 fqdn = [
     {file = "fqdn-1.5.1-py3-none-any.whl", hash = "sha256:3a179af3761e4df6eb2e026ff9e1a3033d3587bf980a0b1b2e1e5d08d7358014"},

--- a/tests/test_create_batch_commands.py
+++ b/tests/test_create_batch_commands.py
@@ -132,17 +132,14 @@ class TestCommandCreator(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         cls.command_creator_output_options_dir = CommandCreator(
-            environment="local",
             phenopacket_path=Path("/path/to/phenopacket.json"),
             phenopacket=phenopacket,
             phenotype_only=False,
             output_options_dir_files=output_options_files,
             output_options_file=None,
             raw_results_dir=Path("/path/to/results_dir"),
-            analysis_yaml=Path("/path/to/exomiser_analysis.yaml"),
         )
         cls.command_creator_output_options_file = CommandCreator(
-            environment="local",
             phenopacket_path=Path("/path/to/phenopacket.json"),
             phenopacket=phenopacket,
             phenotype_only=False,
@@ -151,30 +148,24 @@ class TestCommandCreator(unittest.TestCase):
                 "/full/path/to/some/alternate/output_options/phenopacket-output-options.json"
             ),
             raw_results_dir=Path("/path/to/results_dir"),
-            analysis_yaml=Path("/path/to/exomiser_analysis.yaml"),
         )
         cls.command_creator_none = CommandCreator(
-            environment="local",
             phenopacket_path=Path("/path/to/phenopacket.json"),
             phenopacket=phenopacket,
             phenotype_only=False,
             output_options_dir_files=None,
             output_options_file=None,
             raw_results_dir=Path("/path/to/results_dir"),
-            analysis_yaml=Path("/path/to/exomiser_analysis.yaml"),
         )
         cls.command_creator_phenotype_only = CommandCreator(
-            environment="local",
             phenopacket_path=Path("/path/to/phenopacket.json"),
             phenopacket=phenopacket,
             phenotype_only=True,
             output_options_dir_files=None,
             output_options_file=None,
             raw_results_dir=Path("/path/to/results_dir"),
-            analysis_yaml=None,
         )
         cls.command_creator_phenotype_only_output_options = CommandCreator(
-            environment="local",
             phenopacket_path=Path("/path/to/phenopacket.json"),
             phenopacket=phenopacket,
             phenotype_only=True,
@@ -183,7 +174,6 @@ class TestCommandCreator(unittest.TestCase):
                 "/full/path/to/some/alternate/output_options/phenopacket-output-options.json"
             ),
             raw_results_dir=Path("/path/to/results_dir"),
-            analysis_yaml=None,
         )
 
     def test_assign_output_options_file_from_dir(self):
@@ -242,7 +232,6 @@ class TestCommandCreator(unittest.TestCase):
                 output_options_file=Path(
                     "/full/path/to/some/alternate/output_options/phenopacket-output-options.json"
                 ),
-                analysis_yaml=Path("/path/to/exomiser_analysis.yaml"),
             ),
         )
 
@@ -255,7 +244,6 @@ class TestCommandCreator(unittest.TestCase):
                 vcf_assembly="GRCh37",
                 raw_results_dir=Path("/path/to/results_dir"),
                 phenotype_only=False,
-                analysis_yaml=Path("/path/to/exomiser_analysis.yaml"),
             ),
         )
 
@@ -273,7 +261,6 @@ class TestCommandCreator(unittest.TestCase):
                 output_options_file=Path(
                     "/full/path/to/some/alternate/output_options/phenopacket-output-options.json"
                 ),
-                analysis_yaml=Path("/path/to/exomiser_analysis.yaml"),
             ),
         )
 

--- a/tests/test_create_batch_commands.py
+++ b/tests/test_create_batch_commands.py
@@ -89,7 +89,7 @@ phenotypic_features_with_excluded = [
 phenopacket_files = [
     File(
         uri="test/path/to/test_1.vcf",
-        file_attributes={"fileFormat": "VCF", "genomeAssembly": "GRCh37"},
+        file_attributes={"fileFormat": "vcf", "genomeAssembly": "GRCh37"},
     ),
     File(
         uri="test_1.ped",

--- a/tests/test_create_batch_commands.py
+++ b/tests/test_create_batch_commands.py
@@ -132,14 +132,17 @@ class TestCommandCreator(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         cls.command_creator_output_options_dir = CommandCreator(
+            environment="local",
             phenopacket_path=Path("/path/to/phenopacket.json"),
             phenopacket=phenopacket,
             phenotype_only=False,
             output_options_dir_files=output_options_files,
             output_options_file=None,
             raw_results_dir=Path("/path/to/results_dir"),
+            analysis_yaml=Path("/path/to/exomiser_analysis.yaml"),
         )
         cls.command_creator_output_options_file = CommandCreator(
+            environment="local",
             phenopacket_path=Path("/path/to/phenopacket.json"),
             phenopacket=phenopacket,
             phenotype_only=False,
@@ -148,24 +151,30 @@ class TestCommandCreator(unittest.TestCase):
                 "/full/path/to/some/alternate/output_options/phenopacket-output-options.json"
             ),
             raw_results_dir=Path("/path/to/results_dir"),
+            analysis_yaml=Path("/path/to/exomiser_analysis.yaml"),
         )
         cls.command_creator_none = CommandCreator(
+            environment="local",
             phenopacket_path=Path("/path/to/phenopacket.json"),
             phenopacket=phenopacket,
             phenotype_only=False,
             output_options_dir_files=None,
             output_options_file=None,
             raw_results_dir=Path("/path/to/results_dir"),
+            analysis_yaml=Path("/path/to/exomiser_analysis.yaml"),
         )
         cls.command_creator_phenotype_only = CommandCreator(
+            environment="local",
             phenopacket_path=Path("/path/to/phenopacket.json"),
             phenopacket=phenopacket,
             phenotype_only=True,
             output_options_dir_files=None,
             output_options_file=None,
             raw_results_dir=Path("/path/to/results_dir"),
+            analysis_yaml=None,
         )
         cls.command_creator_phenotype_only_output_options = CommandCreator(
+            environment="local",
             phenopacket_path=Path("/path/to/phenopacket.json"),
             phenopacket=phenopacket,
             phenotype_only=True,
@@ -174,6 +183,7 @@ class TestCommandCreator(unittest.TestCase):
                 "/full/path/to/some/alternate/output_options/phenopacket-output-options.json"
             ),
             raw_results_dir=Path("/path/to/results_dir"),
+            analysis_yaml=None,
         )
 
     def test_assign_output_options_file_from_dir(self):
@@ -232,6 +242,7 @@ class TestCommandCreator(unittest.TestCase):
                 output_options_file=Path(
                     "/full/path/to/some/alternate/output_options/phenopacket-output-options.json"
                 ),
+                analysis_yaml=Path("/path/to/exomiser_analysis.yaml"),
             ),
         )
 
@@ -244,6 +255,7 @@ class TestCommandCreator(unittest.TestCase):
                 vcf_assembly="GRCh37",
                 raw_results_dir=Path("/path/to/results_dir"),
                 phenotype_only=False,
+                analysis_yaml=Path("/path/to/exomiser_analysis.yaml"),
             ),
         )
 
@@ -261,6 +273,7 @@ class TestCommandCreator(unittest.TestCase):
                 output_options_file=Path(
                     "/full/path/to/some/alternate/output_options/phenopacket-output-options.json"
                 ),
+                analysis_yaml=Path("/path/to/exomiser_analysis.yaml"),
             ),
         )
 


### PR DESCRIPTION
Fixed the phenopacket testdata in `test_create_batch_commands.py` so that the `fileFormat` is correctly in the phenopacket `files`.