### PR TITLE
removing exomiser_software_directory variable

### DIFF
--- a/src/pheval_exomiser/prepare/tool_specific_configuration_options.py
+++ b/src/pheval_exomiser/prepare/tool_specific_configuration_options.py
@@ -54,7 +54,6 @@ class ExomiserConfigurations(BaseModel):
     """
 
     environment: str = Field(...)
-    exomiser_software_directory: Path = Field(...)
     analysis_configuration_file: Path = Field(...)
     max_jobs: int = Field(...)
     application_properties: ApplicationProperties = Field(...)

--- a/src/pheval_exomiser/run/run.py
+++ b/src/pheval_exomiser/run/run.py
@@ -105,7 +105,6 @@ def mount_docker(
 def run_exomiser_local(
     input_dir: Path,
     testdata_dir: Path,
-    config: ExomiserConfigurations,
     output_dir: Path,
     tool_input_commands_dir: Path,
     exomiser_version: str,
@@ -120,10 +119,10 @@ def run_exomiser_local(
     ]
     exomiser_jar_file = [
         filename
-        for filename in all_files(input_dir.joinpath(config.exomiser_software_directory))
+        for filename in all_files(input_dir)
         if filename.name.endswith(".jar")
     ][0]
-    exomiser_jar_file_path = config.exomiser_software_directory.joinpath(exomiser_jar_file)
+    exomiser_jar_file_path = input_dir.joinpath(exomiser_jar_file)
     for file in batch_files:
         subprocess.run(
             [
@@ -206,7 +205,7 @@ def run_exomiser(
 ):
     """Run Exomiser with specified environment."""
     run_exomiser_local(
-        input_dir, testdata_dir, config, output_dir, tool_input_commands_dir, exomiser_version
+        input_dir, testdata_dir, output_dir, tool_input_commands_dir, exomiser_version
     ) if config.environment == "local" else run_exomiser_docker(
         input_dir,
         testdata_dir,


### PR DESCRIPTION
Removing the `exomiser_software_directory` from the `config.yaml` as the contents of the Exomiser distribution folder are symlinked to configuration folder and so does not need to specified. This just needed to be detailed in the README.md for a single run and how the configuration folder needs to be set up