### PR TITLE
49 remove usrbinjava from command used to invoke exomiser

### DIFF
--- a/src/pheval_exomiser/run/run.py
+++ b/src/pheval_exomiser/run/run.py
@@ -117,7 +117,7 @@ def run_exomiser_local(
     for file in batch_files:
         subprocess.run(
             [
-                "/usr/bin/java",
+                "java",
                 "-Xmx4g",
                 "-jar",
                 exomiser_jar_file_path,

--- a/tox.ini
+++ b/tox.ini
@@ -64,7 +64,7 @@ ignore =
     #S108 # Probable insecure usage of temp file/directory.
     #S307 # Use of possibly insecure function - consider using safer ast.literal_eval.
     #S603 # subprocess call - check for execution of untrusted input.
-    #S607 # Starting a process with a partial executable path ["open" in both cases]
+    S607 # Starting a process with a partial executable path ["java"]
     #S608 # Possible SQL injection vector through string-based query construction.
     #B024 # StreamingWriter is an abstract base class, but it has no abstract methods. 
          # Remember to use @abstractmethod, @abstractclassmethod and/or @abstractproperty decorators.


### PR DESCRIPTION
Removed `/usr/bin/java/` full path execution for Exomiser jar file - this is because this may not be the correct execution path for java especially when running in different environments (e.g., HPC)