### PR TITLE
53 trim exomiser from pheval result tsv file names

### DIFF
--- a/src/pheval_exomiser/post_process/post_process_results_format.py
+++ b/src/pheval_exomiser/post_process/post_process_results_format.py
@@ -178,7 +178,7 @@ def create_standardised_results(
                 pheval_result=pheval_gene_requirements,
                 sort_order_str=sort_order,
                 output_dir=output_dir,
-                tool_result_path=trim_exomiser_result_filename(trim_exomiser_result_filename()),
+                tool_result_path=trim_exomiser_result_filename(exomiser_json_result),
             )
         if variant_analysis:
             pheval_variant_requirements = PhEvalVariantResultFromExomiserJsonCreator(

--- a/src/pheval_exomiser/post_process/post_process_results_format.py
+++ b/src/pheval_exomiser/post_process/post_process_results_format.py
@@ -178,7 +178,7 @@ def create_standardised_results(
                 pheval_result=pheval_gene_requirements,
                 sort_order_str=sort_order,
                 output_dir=output_dir,
-                tool_result_path=exomiser_json_result,
+                tool_result_path=trim_exomiser_result_filename(trim_exomiser_result_filename()),
             )
         if variant_analysis:
             pheval_variant_requirements = PhEvalVariantResultFromExomiserJsonCreator(
@@ -188,7 +188,7 @@ def create_standardised_results(
                 pheval_result=pheval_variant_requirements,
                 sort_order_str=sort_order,
                 output_dir=output_dir,
-                tool_result_path=exomiser_json_result,
+                tool_result_path=trim_exomiser_result_filename(exomiser_json_result),
             )
         if disease_analysis:
             pheval_disease_requirements = PhEvalDiseaseResultFromExomiserJsonCreator(
@@ -198,7 +198,7 @@ def create_standardised_results(
                 pheval_result=pheval_disease_requirements,
                 sort_order_str=sort_order,
                 output_dir=output_dir,
-                tool_result_path=exomiser_json_result,
+                tool_result_path=trim_exomiser_result_filename(exomiser_json_result),
             )
 
 


### PR DESCRIPTION
Trimming the `-exomiser` from pheval tsv results.

`{phenopacket_name}-exomiser-pheval_gene_result.tsv` -> `{phenopacket_name}-pheval_gene_result.tsv`