### PR TITLE
Setting the Exomiser raw output filename

### DIFF
--- a/src/pheval_exomiser/prepare/create_batch_commands.py
+++ b/src/pheval_exomiser/prepare/create_batch_commands.py
@@ -182,6 +182,8 @@ class CommandsWriter:
                 + str(command_arguments.vcf_file)
                 + " --assembly "
                 + command_arguments.vcf_assembly
+                + " --output-filename "
+                + f"{command_arguments.sample.stem}-exomiser"
             )
         except IOError:
             print("Error writing ", self.file)


### PR DESCRIPTION
Set the Exomsier raw output filenames to `{phenopacket.stem}-exomiser` as Exomiser defaults to the name of the VCF file for the naming of the output.