### PR TITLE
57 exomiser v14 whitelist option in application.properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ tool_specific_configuration_options:
     cadd_version:
     hg19_data_version: 2302
     hg19_local_frequency_path: # name of hg19 local frequency file 
-    hg19_whitelist: 2302_hg19_clinvar_whitelist.tsv.gz # only required for Exomiser v13.3.0 and earlier, can be left blank for Exomiser v14.0.0 onwards.
+    hg19_whitelist_path: 2302_hg19_clinvar_whitelist.tsv.gz # only required for Exomiser v13.3.0 and earlier, can be left blank for Exomiser v14.0.0 onwards.
     hg38_data_version: 2302
     hg38_local_frequency_path: # name of hg38 local frequency file 
-    hg38_whitelist:
+    hg38_whitelist_path:
     phenotype_data_version: 2302
     cache_type:
     cache_caffeine_spec:

--- a/README.md
+++ b/README.md
@@ -35,8 +35,10 @@ tool_specific_configuration_options:
     cadd_version:
     hg19_data_version: 2302
     hg19_local_frequency_path: # name of hg19 local frequency file 
+    hg19_whitelist: 2302_hg19_clinvar_whitelist.tsv.gz # only required for Exomiser v13.3.0 and earlier, can be left blank for Exomiser v14.0.0 onwards.
     hg38_data_version: 2302
     hg38_local_frequency_path: # name of hg38 local frequency file 
+    hg38_whitelist:
     phenotype_data_version: 2302
     cache_type:
     cache_caffeine_spec:
@@ -51,6 +53,8 @@ The Exomiser input data directories (phenotype database and variant database) sh
 The `exomiser_software_directory` points to the name of the Exomiser distribution directory located in the input directory.
 
 The analysis configuration file (in this case: `preset-exome-analysis.yml`) should be located within the input directory.
+
+The whitelist paths for the hg19 and hg38 dbs need only be specified for Exomiser v13.3.0 and earlier (unless specifying your own whitelist), as Exomiser v14.0.0 now includes this in the db.
 
 If using optional databases, such as REMM/CADD/local frequency the optional data input should look like so in the input
 directory:

--- a/config.yaml
+++ b/config.yaml
@@ -14,10 +14,10 @@ tool_specific_configuration_options:
     cadd_version:
     hg19_data_version: 2302
     hg19_local_frequency_path:
-    hg19_whitelist:
+    hg19_whitelist_path:
     hg38_data_version: 2302
     hg38_local_frequency_path:
-    hg38_whitelist:
+    hg38_whitelist_path:
     phenotype_data_version: 2302
     # either none, simple, or caffeine
     cache_type: none

--- a/config.yaml
+++ b/config.yaml
@@ -14,8 +14,10 @@ tool_specific_configuration_options:
     cadd_version:
     hg19_data_version: 2302
     hg19_local_frequency_path:
+    hg19_whitelist:
     hg38_data_version: 2302
     hg38_local_frequency_path:
+    hg38_whitelist:
     phenotype_data_version: 2302
     # either none, simple, or caffeine
     cache_type: none

--- a/src/pheval_exomiser/prepare/tool_specific_configuration_options.py
+++ b/src/pheval_exomiser/prepare/tool_specific_configuration_options.py
@@ -11,8 +11,10 @@ class ApplicationProperties(BaseModel):
         cadd_version (str): Version of the CADD database
         hg19_data_version (str): Data version of the hg19 Exomiser data
         hg19_local_frequency_path (Path): The file name of the hg19 local frequency file
+        hg19_whitelist (Path): The file name of the hg19 whitelist.
         hg38_data_version (str): Data version of the hg38 Exomiser data
         hg38_local_frequency_path (Path): The file name of the hg38 local frequency file
+        hg38_whitelist (Path): The file name of the hg38 whitelist.
         phenotype_data_version (str): Data version of the Exomiser phenotype data
         cache_caffeine_spec (int): Cache limit
     """
@@ -21,8 +23,10 @@ class ApplicationProperties(BaseModel):
     cadd_version: str = Field(None)
     hg19_data_version: str = Field(None)
     hg19_local_frequency_path: Path = Field(None)
+    hg19_whitelist: Path = Field(None)
     hg38_data_version: str = Field(None)
     hg38_local_frequency_path: Path = Field(None)
+    hg38_whitelist: Path = Field(None)
     phenotype_data_version: str = Field(None)
     cache_type: str = Field(None)
     cache_caffeine_spec: int = Field(None)

--- a/src/pheval_exomiser/prepare/tool_specific_configuration_options.py
+++ b/src/pheval_exomiser/prepare/tool_specific_configuration_options.py
@@ -11,10 +11,10 @@ class ApplicationProperties(BaseModel):
         cadd_version (str): Version of the CADD database
         hg19_data_version (str): Data version of the hg19 Exomiser data
         hg19_local_frequency_path (Path): The file name of the hg19 local frequency file
-        hg19_whitelist (Path): The file name of the hg19 whitelist.
+        hg19_whitelist_path (Path): The file name of the hg19 whitelist.
         hg38_data_version (str): Data version of the hg38 Exomiser data
         hg38_local_frequency_path (Path): The file name of the hg38 local frequency file
-        hg38_whitelist (Path): The file name of the hg38 whitelist.
+        hg38_whitelist_path (Path): The file name of the hg38 whitelist.
         phenotype_data_version (str): Data version of the Exomiser phenotype data
         cache_caffeine_spec (int): Cache limit
     """
@@ -23,10 +23,10 @@ class ApplicationProperties(BaseModel):
     cadd_version: str = Field(None)
     hg19_data_version: str = Field(None)
     hg19_local_frequency_path: Path = Field(None)
-    hg19_whitelist: Path = Field(None)
+    hg19_whitelist_path: Path = Field(None)
     hg38_data_version: str = Field(None)
     hg38_local_frequency_path: Path = Field(None)
-    hg38_whitelist: Path = Field(None)
+    hg38_whitelist_path: Path = Field(None)
     phenotype_data_version: str = Field(None)
     cache_type: str = Field(None)
     cache_caffeine_spec: int = Field(None)

--- a/src/pheval_exomiser/prepare/write_application_properties.py
+++ b/src/pheval_exomiser/prepare/write_application_properties.py
@@ -144,16 +144,16 @@ class ExomiserConfigurationFileWriter:
 
     def write_hg19_white_list_path(self) -> None:
         """Write the hg19 whitelist path to application.properties file."""
-        if self.configurations.application_properties.hg19_data_version is not None:
+        if self.configurations.application_properties.hg19_whitelist is not None:
             self.application_properties.write(
-                "exomiser.hg19.variant-white-list-path=${exomiser.hg19.data-version}_hg19_clinvar_whitelist.tsv.gz\n"
+                f"exomiser.hg19.variant-white-list-path={self.configurations.application_properties.hg19_whitelist}\n"
             )
 
     def write_hg38_white_list_path(self) -> None:
         """Write the hg38 whitelist path to application.properties file."""
-        if self.configurations.application_properties.hg38_data_version is not None:
+        if self.configurations.application_properties.hg38_whitelist is not None:
             self.application_properties.write(
-                "exomiser.hg38.variant-white-list-path=${exomiser.hg38.data-version}_hg38_clinvar_whitelist.tsv.gz\n"
+                f"exomiser.hg38.variant-white-list-path={self.configurations.application_properties.hg38_whitelist}\n"
             )
 
     def write_cache_type(self):

--- a/src/pheval_exomiser/prepare/write_application_properties.py
+++ b/src/pheval_exomiser/prepare/write_application_properties.py
@@ -144,16 +144,18 @@ class ExomiserConfigurationFileWriter:
 
     def write_hg19_white_list_path(self) -> None:
         """Write the hg19 whitelist path to application.properties file."""
-        if self.configurations.application_properties.hg19_whitelist is not None:
+        if self.configurations.application_properties.hg19_whitelist_path is not None:
             self.application_properties.write(
-                f"exomiser.hg19.variant-white-list-path={self.configurations.application_properties.hg19_whitelist}\n"
+                f"exomiser.hg19.variant-white-list-path="
+                f"{self.configurations.application_properties.hg19_whitelist_path}\n"
             )
 
     def write_hg38_white_list_path(self) -> None:
         """Write the hg38 whitelist path to application.properties file."""
-        if self.configurations.application_properties.hg38_whitelist is not None:
+        if self.configurations.application_properties.hg38_whitelist_path is not None:
             self.application_properties.write(
-                f"exomiser.hg38.variant-white-list-path={self.configurations.application_properties.hg38_whitelist}\n"
+                f"exomiser.hg38.variant-white-list-path="
+                f"{self.configurations.application_properties.hg38_whitelist_path}\n"
             )
 
     def write_cache_type(self):

--- a/tests/test_write_application_properties.py
+++ b/tests/test_write_application_properties.py
@@ -34,6 +34,8 @@ class TestExomiserConfigurationFileWriter(unittest.TestCase):
                     hg38_data_version="2302",
                     cache_type="caffeine",
                     cache_caffeine_spec=60000,
+                    hg19_whitelist="2302_hg19_clinvar_whitelist.tsv.gz",
+                    hg38_whitelist="2302_hg38_clinvar_whitelist.tsv.gz",
                 ),
                 post_process=PostProcessing(score_name="combinedScore", sort_order="descending"),
             ),
@@ -321,14 +323,11 @@ class TestExomiserConfigurationFileWriter(unittest.TestCase):
         config.close()
         self.assertEqual(
             contents,
-            [
-                "exomiser.hg19.variant-white-list-path="
-                "${exomiser.hg19.data-version}_hg19_clinvar_whitelist.tsv.gz\n"
-            ],
+            ["exomiser.hg19.variant-white-list-path=" "2302_hg19_clinvar_whitelist.tsv.gz\n"],
         )
 
     def test_write_hg19_white_list_path_none_specified(self):
-        self.application_properties_settings.configurations.application_properties.hg19_data_version = (
+        self.application_properties_settings.configurations.application_properties.hg19_whitelist = (
             None
         )
         self.application_properties_settings.write_hg19_white_list_path()
@@ -346,14 +345,11 @@ class TestExomiserConfigurationFileWriter(unittest.TestCase):
         config.close()
         self.assertEqual(
             contents,
-            [
-                "exomiser.hg38.variant-white-list-path="
-                "${exomiser.hg38.data-version}_hg38_clinvar_whitelist.tsv.gz\n"
-            ],
+            ["exomiser.hg38.variant-white-list-path=" "2302_hg38_clinvar_whitelist.tsv.gz\n"],
         )
 
     def test_write_hg38_white_list_path_none_specified(self):
-        self.application_properties_settings.configurations.application_properties.hg38_data_version = (
+        self.application_properties_settings.configurations.application_properties.hg38_whitelist = (
             None
         )
         self.application_properties_settings.write_hg38_white_list_path()
@@ -426,8 +422,8 @@ class TestExomiserConfigurationFileWriter(unittest.TestCase):
                 "${exomiser.data-directory}/local/local_frequency_test_hg38.tsv.gz\n",
                 "exomiser.hg38.remm-path=${exomiser.data-directory}/remm/ReMM.v${remm.version}.hg38.tsv.gz\n",
                 "exomiser.phenotype.data-version=2302\n",
-                "exomiser.hg19.variant-white-list-path=${exomiser.hg19.data-version}_hg19_clinvar_whitelist.tsv.gz\n",
-                "exomiser.hg38.variant-white-list-path=${exomiser.hg38.data-version}_hg38_clinvar_whitelist.tsv.gz\n",
+                "exomiser.hg19.variant-white-list-path=2302_hg19_clinvar_whitelist.tsv.gz\n",
+                "exomiser.hg38.variant-white-list-path=2302_hg38_clinvar_whitelist.tsv.gz\n",
                 "remm.version=0.3.1.post1\n",
             ],
         )

--- a/tests/test_write_application_properties.py
+++ b/tests/test_write_application_properties.py
@@ -34,8 +34,8 @@ class TestExomiserConfigurationFileWriter(unittest.TestCase):
                     hg38_data_version="2302",
                     cache_type="caffeine",
                     cache_caffeine_spec=60000,
-                    hg19_whitelist="2302_hg19_clinvar_whitelist.tsv.gz",
-                    hg38_whitelist="2302_hg38_clinvar_whitelist.tsv.gz",
+                    hg19_whitelist_path="2302_hg19_clinvar_whitelist.tsv.gz",
+                    hg38_whitelist_path="2302_hg38_clinvar_whitelist.tsv.gz",
                 ),
                 post_process=PostProcessing(score_name="combinedScore", sort_order="descending"),
             ),
@@ -327,7 +327,7 @@ class TestExomiserConfigurationFileWriter(unittest.TestCase):
         )
 
     def test_write_hg19_white_list_path_none_specified(self):
-        self.application_properties_settings.configurations.application_properties.hg19_whitelist = (
+        self.application_properties_settings.configurations.application_properties.hg19_whitelist_path = (
             None
         )
         self.application_properties_settings.write_hg19_white_list_path()
@@ -349,7 +349,7 @@ class TestExomiserConfigurationFileWriter(unittest.TestCase):
         )
 
     def test_write_hg38_white_list_path_none_specified(self):
-        self.application_properties_settings.configurations.application_properties.hg38_whitelist = (
+        self.application_properties_settings.configurations.application_properties.hg38_whitelist_path = (
             None
         )
         self.application_properties_settings.write_hg38_white_list_path()


### PR DESCRIPTION
Changed the default writing of the whitelist to the application.properties. Now, this will need to be specified in the `config.yaml` - this will avoid errors when running with Exomiser 14.0.0 (as it is now included in the dbs) and allow running with 13.3.0 and earlier.