### PR TITLE
Remove Duplicate Disease Results in PhEval TSV Output Based on Disease and Score

### DIFF
--- a/src/pheval_exomiser/post_process/post_process_results_format.py
+++ b/src/pheval_exomiser/post_process/post_process_results_format.py
@@ -182,7 +182,12 @@ class PhEvalDiseaseResultFromExomiserJsonCreator:
                     )
             except KeyError:
                 pass
-        return simplified_exomiser_result
+        return list(
+            {
+                (result.disease_identifier, result.score): result
+                for result in simplified_exomiser_result
+            }.values()
+        )
 
 
 def create_standardised_results(


### PR DESCRIPTION
This addresses an issue where duplicated disease results were appearing in the PhEval TSV output during disease prioritisation in phenotype-only mode. Specifically, the same disease was being listed multiple times with identical scores, which was negatively affecting the ranking and penalising Exomiser’s performance. 

The issue arose because the disease results were being retrieved at the gene-to-disease association level, leading to multiple entries for the same disease when different genes were linked to it.