### PR TITLE
68 account for compound het variants

### DIFF
--- a/tests/test_post_process_results_format.py
+++ b/tests/test_post_process_results_format.py
@@ -1,5 +1,6 @@
 import unittest
 from copy import copy
+from unittest.mock import patch
 
 from pheval.post_processing.post_processing import (
     PhEvalDiseaseResult,
@@ -2665,31 +2666,71 @@ class TestPhEvalVariantFromExomiserJsonCreator(unittest.TestCase):
             )
         )
 
-    def test_extract_pheval_variant_requirements(self):
+    @patch.object(
+        PhEvalVariantResultFromExomiserJsonCreator,
+        "add_or_find_variant_group",
+        return_value="mocked_id",
+    )
+    def test_extract_pheval_variant_requirements(self, mock_add_or_find_variant_group):
         self.assertEqual(
             self.json_result.extract_pheval_variant_requirements(),
             [
                 PhEvalVariantResult(
-                    chromosome="3", start=126730873, end=126730873, ref="G", alt="A", score=0.0484
+                    chromosome="3",
+                    start=126730873,
+                    end=126730873,
+                    ref="G",
+                    alt="A",
+                    score=0.0484,
+                    grouping_id="mocked_id",
                 ),
                 PhEvalVariantResult(
-                    chromosome="3", start=126730873, end=126730873, ref="G", alt="A", score=0.0484
+                    chromosome="3",
+                    start=126730873,
+                    end=126730873,
+                    ref="G",
+                    alt="A",
+                    score=0.0484,
+                    grouping_id="mocked_id",
                 ),
                 PhEvalVariantResult(
-                    chromosome="3", start=126741108, end=126741108, ref="G", alt="A", score=0.0484
+                    chromosome="3",
+                    start=126741108,
+                    end=126741108,
+                    ref="G",
+                    alt="A",
+                    score=0.0484,
+                    grouping_id="mocked_id",
                 ),
             ],
         )
 
-    def test_extract_pheval_variant_requirements_filter_acmg(self):
+    @patch.object(
+        PhEvalVariantResultFromExomiserJsonCreator,
+        "add_or_find_variant_group",
+        return_value="mocked_id",
+    )
+    def test_extract_pheval_variant_requirements_filter_acmg(self, mock_add_or_find_variant_group):
         self.assertEqual(
             self.json_result.extract_pheval_variant_requirements(True),
             [
                 PhEvalVariantResult(
-                    chromosome="3", start=126730873, end=126730873, ref="G", alt="A", score=0.0484
+                    chromosome="3",
+                    start=126730873,
+                    end=126730873,
+                    ref="G",
+                    alt="A",
+                    score=0.0484,
+                    grouping_id="mocked_id",
                 ),
                 PhEvalVariantResult(
-                    chromosome="3", start=126741108, end=126741108, ref="G", alt="A", score=0.0484
+                    chromosome="3",
+                    start=126741108,
+                    end=126741108,
+                    ref="G",
+                    alt="A",
+                    score=0.0484,
+                    grouping_id="mocked_id",
                 ),
             ],
         )

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ envlist =
 
 [testenv]
 commands =
+    pip install pheval
     coverage run -p -m pytest --durations=20 {posargs:tests}
     coverage combine
     coverage xml

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,6 @@ envlist =
 
 [testenv]
 commands =
-    pip install pheval
     coverage run -p -m pytest --durations=20 {posargs:tests}
     coverage combine
     coverage xml

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,6 @@ envlist =
 
 [testenv]
 commands =
-    pip install -e ../pheval
     coverage run -p -m pytest --durations=20 {posargs:tests}
     coverage combine
     coverage xml


### PR DESCRIPTION
Add `grouping_id` to account for compound heterzygous variants.

For reference compound heterzygous variants include:
* Variants with the same Exomiser combined score
* Occur in the same gene
* Fall under a reccessive mode of inheritance

This allows compound het variants to be accounted for a the same entity without penalising the ranking.

NOTE - This should not be merged until [#368](https://github.com/monarch-initiative/pheval/pull/368) in PhEval is reviewed & merged