### PR TITLE
70 validation error in `config.yaml` for empty fields

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pheval_exomiser"
-version = "0.2.5"
+version = "0.2.6"
 description = ""
 authors = ["Yasemin Bridges <y.bridges@qmul.ac.uk>",
     "Julius Jacobsen <j.jacobsen@qmul.ac.uk>",

--- a/src/pheval_exomiser/prepare/tool_specific_configuration_options.py
+++ b/src/pheval_exomiser/prepare/tool_specific_configuration_options.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 
 from pydantic import BaseModel, Field
 
@@ -20,17 +20,17 @@ class ApplicationProperties(BaseModel):
         cache_caffeine_spec (int): Cache limit
     """
 
-    remm_version: str = Field(None)
-    cadd_version: str = Field(None)
-    hg19_data_version: str = Field(None)
-    hg19_local_frequency_path: Path = Field(None)
-    hg19_whitelist_path: Path = Field(None)
-    hg38_data_version: str = Field(None)
-    hg38_local_frequency_path: Path = Field(None)
-    hg38_whitelist_path: Path = Field(None)
-    phenotype_data_version: str = Field(None)
-    cache_type: str = Field(None)
-    cache_caffeine_spec: int = Field(None)
+    remm_version: Optional[str] = Field(None)
+    cadd_version: Optional[str] = Field(None)
+    hg19_data_version: Optional[str] = Field(None)
+    hg19_local_frequency_path: Optional[Path] = Field(None)
+    hg19_whitelist_path: Optional[Path] = Field(None)
+    hg38_data_version: Optional[str] = Field(None)
+    hg38_local_frequency_path: Optional[Path] = Field(None)
+    hg38_whitelist_path: Optional[Path] = Field(None)
+    phenotype_data_version: Optional[str] = Field(None)
+    cache_type: Optional[str] = Field(None)
+    cache_caffeine_spec: Optional[int] = Field(None)
 
 
 class PostProcessing(BaseModel):
@@ -64,5 +64,5 @@ class ExomiserConfigurations(BaseModel):
     analysis_configuration_file: Path = Field(...)
     max_jobs: int = Field(...)
     application_properties: ApplicationProperties = Field(...)
-    output_formats: List[str] = Field(None)
+    output_formats: Optional[List[str]] = Field(None)
     post_process: PostProcessing = Field(...)


### PR DESCRIPTION
A validation occurred when intended optional fields in the `config.yaml` were left blank. Ensured the typing on these variables so that they can be left blank and the run execute without error.