### PR TITLE
80 make vcf directory optional in testdata directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,9 @@ e.g.,
    └── vcf
 ```
 
+> [!IMPORTANT]  
+> If a `vcf` directory is not found in the testdata directory then the path to the VCF will be taken from the phenopacket if `variant_analysis` is set to True.
+
 ## Run command
 
 Once the testdata and input directories are correctly configured for the run, the `pheval run` command can be executed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pheval_exomiser"
-version = "0.3.0"
+version = "0.3.1"
 description = ""
 authors = ["Yasemin Bridges <y.bridges@qmul.ac.uk>",
     "Julius Jacobsen <j.jacobsen@qmul.ac.uk>",

--- a/src/pheval_exomiser/prepare/create_batch_commands.py
+++ b/src/pheval_exomiser/prepare/create_batch_commands.py
@@ -100,8 +100,14 @@ class CommandCreator:
             )
 
     def add_variant_analysis_arguments(self, vcf_dir: Path) -> ExomiserCommandLineArguments:
-        vcf_file_data = PhenopacketUtil(self.phenopacket).vcf_file_data(
-            self.phenopacket_path, vcf_dir
+        vcf_file_data = (
+            PhenopacketUtil(self.phenopacket).vcf_file_data(self.phenopacket_path, vcf_dir)
+            if vcf_dir.exists()
+            else [
+                file
+                for file in self.phenopacket.files
+                if file.file_attributes["fileFormat"] == "vcf"
+            ][0]
         )
         output_options_file = self.assign_output_options_file()
         if self.environment == "local":

--- a/tests/test_create_batch_commands.py
+++ b/tests/test_create_batch_commands.py
@@ -1,5 +1,6 @@
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 from phenopackets import (
     Diagnosis,
@@ -235,7 +236,8 @@ class TestCommandCreator(unittest.TestCase):
             ),
         )
 
-    def test_add_variant_analysis_arguments(self):
+    @patch("pathlib.Path.exists", return_value=True)
+    def test_add_variant_analysis_arguments(self, mock_exists):
         self.assertEqual(
             self.command_creator_output_options_dir.add_variant_analysis_arguments(
                 Path("/path/to/vcf_dir")
@@ -254,7 +256,8 @@ class TestCommandCreator(unittest.TestCase):
             ),
         )
 
-    def test_add_variant_analysis_arguments_none(self):
+    @patch("pathlib.Path.exists", return_value=True)
+    def test_add_variant_analysis_arguments_none(self, mock_exists):
         self.assertEqual(
             self.command_creator_none.add_variant_analysis_arguments(Path("/path/to/vcf_dir")),
             ExomiserCommandLineArguments(
@@ -268,7 +271,8 @@ class TestCommandCreator(unittest.TestCase):
             ),
         )
 
-    def test_add_command_line_arguments(self):
+    @patch("pathlib.Path.exists", return_value=True)
+    def test_add_command_line_arguments(self, mock_exists):
         self.assertEqual(
             self.command_creator_output_options_file.add_command_line_arguments(
                 Path("/path/to/vcf_dir")


### PR DESCRIPTION
If there isn't a `vcf` directory in the testdata directory then default to the VCF path specified in the phenopacket. This is useful for secured environments where you cannot move file locations.