### PR TITLE
83 error reading json with polars due to extra field label

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pheval_exomiser"
-version = "0.3.1"
+version = "0.3.2"
 description = ""
 authors = ["Yasemin Bridges <y.bridges@qmul.ac.uk>",
     "Julius Jacobsen <j.jacobsen@qmul.ac.uk>",

--- a/src/pheval_exomiser/post_process/post_process_results_format.py
+++ b/src/pheval_exomiser/post_process/post_process_results_format.py
@@ -136,7 +136,7 @@ def create_standardised_results(
 ):
     sort_order = SortOrder.ASCENDING if sort_order.lower() == "ascending" else SortOrder.DESCENDING
     for exomiser_json_result_path in files_with_suffix(result_dir, ".json"):
-        exomiser_json_result = pl.read_json(exomiser_json_result_path)
+        exomiser_json_result = pl.read_json(exomiser_json_result_path, infer_schema_length=None)
         if gene_analysis:
             gene_results = extract_gene_results_from_json(exomiser_json_result, score_name)
             generate_gene_result(


### PR DESCRIPTION
Increased `infer_schema_length` to prevent errors due to a extra field in the Exomiser JSON file when parsing the results into PhEval standardised format